### PR TITLE
Poprawki do lab4

### DIFF
--- a/lab4_nn_module.ipynb
+++ b/lab4_nn_module.ipynb
@@ -45,8 +45,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open('data/hpmor_part.txt', 'r', encoding='utf-8-sig') as file:\n",
-    "    text = file.read()"
+    "import requests\n",
+    "\n",
+    "url = \"https://github.com/asztyber/jak_dziala_gpt_lab/blob/main/data/hpmor_part.txt?raw=true\"\n",
+    "response = requests.get(url)\n",
+    "text = response.text"
    ]
   },
   {
@@ -91,7 +94,7 @@
     "        logits = model(torch.tensor(ch_to_idx[last_ch], device=device)) #<- zmiana\n",
     "        probs = F.softmax(logits, dim=0) #<- zmiana\n",
     "        probs = probs.cpu().detach().numpy()\n",
-    "        next_ch = idx_to_ch[np.random.choice(n, p=probs)]\n",
+    "        next_ch = idx_to_ch[np.random.choice(n_tokens, p=probs)]\n",
     "        start_seq += next_ch\n",
     "    return start_seq"
    ]


### PR DESCRIPTION
Rozwiązanie zajęło mi niecałe 20 minut.
Poprawki:
1. Ściągnięcie pliku z textem przez requesta zamiast z pliku lokalnego (oczywiście mogą go sobie wrzucić lokalnie, ale skoro już tak było w labie 2 to może niech i tak będzie tutaj).
2. W funkcji do generowania textu zamiana n na n_tokens (zmienna n nie istnieje).

Uwagi:
1. Być może warto im powiedzieć, że to x, y też muszą "wysłać" do device. Jeśli nie będą jeszcze używali GPU na tych labach to oczywiście nie trzeba, ale jeśli będą to model będzie na GPU, a x i y domyślnie nie.